### PR TITLE
Make it possible to run CLI with `go run` directly

### DIFF
--- a/cmd/dictator.go
+++ b/cmd/dictator.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/vkrasnov/dictator"
+	".."
 	"io/ioutil"
 	"log"
 	"math"


### PR DESCRIPTION
With this change I was able to do `go run cmd/dictator.go`.
Not sure if this is a correct way of doing things, I'm a golang developer, but for me it is strange to require external dependency if its source code is one level higher in filesystem.